### PR TITLE
Provide ActionReducerMap<T> everywhere in example-app

### DIFF
--- a/example-app/app/auth/reducers/index.ts
+++ b/example-app/app/auth/reducers/index.ts
@@ -1,4 +1,8 @@
-import { createSelector, createFeatureSelector } from '@ngrx/store';
+import {
+  createSelector,
+  createFeatureSelector,
+  ActionReducerMap,
+} from '@ngrx/store';
 import * as fromRoot from '../../reducers';
 import * as fromAuth from './auth';
 import * as fromLoginPage from './login-page';
@@ -12,7 +16,7 @@ export interface State extends fromRoot.State {
   auth: AuthState;
 }
 
-export const reducers = {
+export const reducers: ActionReducerMap<AuthState> = {
   status: fromAuth.reducer,
   loginPage: fromLoginPage.reducer,
 };

--- a/example-app/app/books/reducers/index.ts
+++ b/example-app/app/books/reducers/index.ts
@@ -1,4 +1,8 @@
-import { createSelector, createFeatureSelector } from '@ngrx/store';
+import {
+  createSelector,
+  createFeatureSelector,
+  ActionReducerMap,
+} from '@ngrx/store';
 import * as fromSearch from './search';
 import * as fromBooks from './books';
 import * as fromCollection from './collection';
@@ -14,7 +18,7 @@ export interface State extends fromRoot.State {
   books: BooksState;
 }
 
-export const reducers = {
+export const reducers: ActionReducerMap<BooksState> = {
   search: fromSearch.reducer,
   books: fromBooks.reducer,
   collection: fromCollection.reducer,


### PR DESCRIPTION
In the example-app, provide the ActionReducerMap<T> in the books and auth reducer maps for [added type checking](https://github.com/ngrx/platform/blob/master/docs/store/actions.md).  This makes the example-app a better example of best practices.